### PR TITLE
Link SelfField from the personal site

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ const work = [
   { index: '01', name: 'taskflow', description: '让多智能体工作流可以验证、恢复与重放。', tech: 'TypeScript', href: 'https://github.com/heggria/taskflow' },
   { index: '02', name: 'Hermit', description: '为长期任务构建有边界、可追溯的本地内核。', tech: 'Python', href: 'https://pypi.org/project/hermit-agent/' },
   { index: '03', name: 'Home Compass', description: '在真实约束中，把住房选择变成可解释的决策。', tech: 'Next.js', href: 'https://github.com/heggria/home-compass' },
-  { index: '04', name: 'SBTI Lab', description: '探索一面不把人简化成类型的个人镜子。', tech: 'TypeScript', href: 'https://github.com/heggria/sbti-lab' },
+  { index: '04', name: 'SelfField', description: '从真实经历与矛盾中，形成一面随时间变化的个人镜像。', tech: 'React', href: 'https://heggria.github.io/selffield/' },
 ]
 ---
 


### PR DESCRIPTION
Replace the retired SBTI Lab name and repository link with the live SelfField product and its evidence-first positioning.